### PR TITLE
fix: sort failures appropriately

### DIFF
--- a/lib/print.js
+++ b/lib/print.js
@@ -10,7 +10,18 @@ function printResults(results, colors, compare, mode) {
     let compared = '';
     let standardErrorPadding = 0;
     const entries = Object.entries(results)
-        .sort((a, b) => b[1].mean - a[1].mean)
+        .sort((a, b) => {
+        if (!a[1].success && !b[1].success) {
+            return 0;
+        }
+        if (a[1].success && !b[1].success) {
+            return 1;
+        }
+        if (!a[1].success && b[1].success) {
+            return -1;
+        }
+        return b[1].mean - a[1].mean;
+    })
         .map(([name, result]) => {
         if (!result.success) {
             return { name, error: result.error, throughput: '', standardError: '', relative: '', compared: '' };

--- a/src/print.ts
+++ b/src/print.ts
@@ -23,7 +23,21 @@ export function printResults(results: Results, colors: boolean, compare: boolean
   let standardErrorPadding = 0
 
   const entries: Array<PrintInfo> = Object.entries(results)
-    .sort((a: [string, Result], b: [string, Result]) => b[1].mean! - a[1].mean!)
+    .sort((a: [string, Result], b: [string, Result]) => {
+      if (!a[1].success && !b[1].success) {
+        return 0
+      }
+
+      if (a[1].success && !b[1].success) {
+        return 1
+      }
+
+      if (!a[1].success && b[1].success) {
+        return -1
+      }
+
+      return b[1].mean! - a[1].mean!
+    })
     .map(([name, result]: [string, Result]) => {
       if (!result.success) {
         return { name, error: result.error, throughput: '', standardError: '', relative: '', compared: '' } as PrintInfo


### PR DESCRIPTION
This makes sure failed items are not shown as fastest.